### PR TITLE
Allow disabling upgrading all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This role is configurable with the following variables:
   system
 * `postmaster_redirect_address`: an e-mail address where *postmaster*/*root*
   e-mails will be redirected to
+* `update_all_packages`: allows disabling upgrading all packages - useful if
+  patching is something only done on a monthly cycle etc.
 
 See the [Example playbook](#example-playbook) section below for a reference of
 these variables’ default values.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ installed_locales:
   - en_US.UTF-8
   - en_IE.UTF-8
 postmaster_redirect_address: root@localhost
+update_all_packages: true

--- a/tasks/_packages.yml
+++ b/tasks/_packages.yml
@@ -19,6 +19,7 @@
 - name: Upgrade all installed packages
   apt:
     upgrade: true
+  when: update_all_packages
 
 - name: Install required packages
   apt:


### PR DESCRIPTION
In various corporates patching is done on a cycle - it's not something that can be run on every iteration of ansible - however it would be nice to re-run the configuration on each patching. As a result I'm adding a flag (leaving the default of enabled) that allows disabling the `apt-get upgrade` call.